### PR TITLE
Implement sign up and persistent login

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,5 @@
 #root {
-  max-width: 1280px;
+  max-width: 1200px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+  padding: 1rem;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,34 +1,66 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useState, useEffect } from 'react'
+import LoginForm from './components/LoginForm'
+import SignUpForm from './components/SignUpForm'
+import SchedulePage from './components/SchedulePage'
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [user, setUser] = useState(null)
+  const [showSign, setShowSign] = useState(false)
 
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+  useEffect(() => {
+    const stored = localStorage.getItem('auth')
+    if (stored) {
+      setUser(JSON.parse(stored))
+    }
+  }, [])
+
+  const handleLogin = async (username, password) => {
+    // 실제로는 백엔드에 요청해야 함
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password }),
+      })
+      if (!res.ok) throw new Error('로그인 실패')
+      const data = await res.json()
+      const userInfo = { name: data.name, token: data.token }
+      setUser(userInfo)
+      localStorage.setItem('auth', JSON.stringify(userInfo))
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+
+  const handleLogout = () => {
+    setUser(null)
+    localStorage.removeItem('auth')
+  }
+
+  const handleSignUp = async (info) => {
+    try {
+      const res = await fetch('/api/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(info),
+      })
+      if (!res.ok) throw new Error('회원가입 실패')
+      alert('가입이 완료되었습니다. 로그인 해주세요.')
+      setShowSign(false)
+    } catch (err) {
+      alert(err.message)
+    }
+  }
+
+  if (user) {
+    return <SchedulePage user={user} onLogout={handleLogout} />
+  }
+
+  return showSign ? (
+    <SignUpForm onSignUp={handleSignUp} onCancel={() => setShowSign(false)} />
+  ) : (
+    <LoginForm onLogin={handleLogin} onShowSignUp={() => setShowSign(true)} />
   )
 }
 

--- a/src/components/LoginForm.css
+++ b/src/components/LoginForm.css
@@ -1,0 +1,31 @@
+.login-wrapper {
+  max-width: 400px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 1rem;
+}
+
+.login-form input {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.login-form button {
+  padding: 0.75rem;
+  font-size: 1rem;
+  width: 100%;
+}

--- a/src/components/LoginForm.jsx
+++ b/src/components/LoginForm.jsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+import './LoginForm.css'
+
+export default function LoginForm({ onLogin, onShowSignUp }) {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    onLogin(username, password)
+  }
+
+  return (
+    <div className="login-wrapper">
+      <h2>로그인</h2>
+      <form onSubmit={handleSubmit} className="login-form">
+        <input
+          type="text"
+          placeholder="아이디"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="비밀번호"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button type="submit">로그인</button>
+        <button type="button" onClick={onShowSignUp}>
+          회원가입
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/src/components/SchedulePage.css
+++ b/src/components/SchedulePage.css
@@ -1,0 +1,54 @@
+.page-wrapper {
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 1rem;
+}
+
+.top-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+}
+
+.user-info {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.form-section {
+  margin-bottom: 2rem;
+}
+
+.schedule-form,
+.post-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
+}
+
+.schedule-list li {
+  margin-bottom: 0.25rem;
+  padding: 0.25rem 0;
+}
+
+.post-item {
+  border: 1px solid #e0e0e0;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background: #fff;
+  border-radius: 8px;
+}
+
+@media (max-width: 600px) {
+  .top-bar {
+    flex-direction: column;
+    gap: 1rem;
+  }
+}

--- a/src/components/SchedulePage.jsx
+++ b/src/components/SchedulePage.jsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import './SchedulePage.css'
+
+export default function SchedulePage({ user, onLogout }) {
+  const [scheduleTitle, setScheduleTitle] = useState('')
+  const [scheduleDate, setScheduleDate] = useState('')
+  const [scheduleDesc, setScheduleDesc] = useState('')
+  const [schedules, setSchedules] = useState([])
+
+  const [postTitle, setPostTitle] = useState('')
+  const [postContent, setPostContent] = useState('')
+  const [posts, setPosts] = useState([])
+
+  const addSchedule = (e) => {
+    e.preventDefault()
+    if (!scheduleTitle || !scheduleDate) return
+    setSchedules([
+      ...schedules,
+      { title: scheduleTitle, date: scheduleDate, desc: scheduleDesc },
+    ])
+    setScheduleTitle('')
+    setScheduleDate('')
+    setScheduleDesc('')
+  }
+
+  const addPost = (e) => {
+    e.preventDefault()
+    if (!postTitle) return
+    setPosts([...posts, { title: postTitle, content: postContent }])
+    setPostTitle('')
+    setPostContent('')
+  }
+
+  return (
+    <div className="page-wrapper">
+      <header className="top-bar">
+        <h1>SmartPlanAI</h1>
+        <div className="user-info">
+          <span>{user.name} 님</span>
+          <button onClick={onLogout}>로그아웃</button>
+        </div>
+      </header>
+
+      <section className="form-section">
+        <h2>일정 등록</h2>
+        <form onSubmit={addSchedule} className="schedule-form">
+          <input
+            type="text"
+            placeholder="제목"
+            value={scheduleTitle}
+            onChange={(e) => setScheduleTitle(e.target.value)}
+            required
+          />
+          <input
+            type="date"
+            value={scheduleDate}
+            onChange={(e) => setScheduleDate(e.target.value)}
+            required
+          />
+          <textarea
+            placeholder="설명"
+            value={scheduleDesc}
+            onChange={(e) => setScheduleDesc(e.target.value)}
+          />
+          <button type="submit">추가</button>
+        </form>
+        <ul className="schedule-list">
+          {schedules.map((s, idx) => (
+            <li key={idx}>
+              <strong>{s.date}</strong> - {s.title}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className="form-section">
+        <h2>게시글 작성</h2>
+        <form onSubmit={addPost} className="post-form">
+          <input
+            type="text"
+            placeholder="제목"
+            value={postTitle}
+            onChange={(e) => setPostTitle(e.target.value)}
+            required
+          />
+          <textarea
+            placeholder="내용"
+            value={postContent}
+            onChange={(e) => setPostContent(e.target.value)}
+          />
+          <button type="submit">작성</button>
+        </form>
+        <div className="post-list">
+          {posts.map((p, idx) => (
+            <article key={idx} className="post-item">
+              <h3>{p.title}</h3>
+              <p>{p.content}</p>
+            </article>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/components/SignUpForm.css
+++ b/src/components/SignUpForm.css
@@ -1,0 +1,36 @@
+.sign-wrapper {
+  max-width: 500px;
+  margin: 2rem auto;
+  padding: 2rem;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.sign-form {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 1rem;
+}
+
+.sign-form input {
+  padding: 0.5rem;
+  font-size: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.sign-form button {
+  padding: 0.75rem;
+  font-size: 1rem;
+  width: 100%;
+}
+
+.check-row {
+  display: flex;
+  gap: 0.5rem;
+}

--- a/src/components/SignUpForm.jsx
+++ b/src/components/SignUpForm.jsx
@@ -1,0 +1,104 @@
+import { useState } from 'react'
+import './SignUpForm.css'
+
+export default function SignUpForm({ onSignUp, onCancel }) {
+  const [username, setUsername] = useState('')
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [password2, setPassword2] = useState('')
+
+  const checkUsername = async () => {
+    if (!username) return
+    try {
+      const res = await fetch('/api/users/check-username', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username }),
+      })
+      const data = await res.json()
+      alert(data.available ? '사용 가능한 아이디입니다.' : '이미 사용 중인 아이디입니다.')
+    } catch (err) {
+      alert('아이디 확인 중 오류')
+    }
+  }
+
+  const checkEmail = async () => {
+    if (!email) return
+    try {
+      const res = await fetch('/api/users/check-email', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      })
+      const data = await res.json()
+      alert(data.available ? '사용 가능한 이메일입니다.' : '이미 사용 중인 이메일입니다.')
+    } catch (err) {
+      alert('이메일 확인 중 오류')
+    }
+  }
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    if (password !== password2) {
+      alert('비밀번호가 일치하지 않습니다')
+      return
+    }
+    onSignUp({ username, name, email, password })
+  }
+
+  return (
+    <div className="sign-wrapper">
+      <h2>회원가입</h2>
+      <form onSubmit={handleSubmit} className="sign-form">
+        <div className="check-row">
+          <input
+            type="text"
+            placeholder="아이디"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+          />
+          <button type="button" onClick={checkUsername} style={{ width: 'auto' }}>
+            중복확인
+          </button>
+        </div>
+        <input
+          type="text"
+          placeholder="이름"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+        <div className="check-row">
+          <input
+            type="email"
+            placeholder="이메일"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <button type="button" onClick={checkEmail} style={{ width: 'auto' }}>
+            중복확인
+          </button>
+        </div>
+        <input
+          type="password"
+          placeholder="비밀번호"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="비밀번호 확인"
+          value={password2}
+          onChange={(e) => setPassword2(e.target.value)}
+          required
+        />
+        <button type="submit">가입하기</button>
+        <button type="button" onClick={onCancel}>취소</button>
+      </form>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -3,9 +3,8 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: #333;
+  background-color: #f5f7fa;
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -28,6 +27,8 @@ body {
   place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background-color: #f5f7fa;
+  color: #333;
 }
 
 h1 {
@@ -37,32 +38,21 @@ h1 {
 
 button {
   border-radius: 8px;
-  border: 1px solid transparent;
+  border: none;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: #2d79f7;
+  color: #fff;
   cursor: pointer;
-  transition: border-color 0.25s;
+  transition: background-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  background-color: #1d60d1;
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
-}


### PR DESCRIPTION
## Summary
- add bright theme styles
- enhance login form with sign-up option
- create SignUpForm with username/email checks
- persist login token with localStorage
- style schedule and post forms with white cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d903b8c64832da132bf7c6e8986b0